### PR TITLE
Fix podspec

### DIFF
--- a/ios/RNAppMetadata.podspec
+++ b/ios/RNAppMetadata.podspec
@@ -3,22 +3,15 @@ Pod::Spec.new do |s|
   s.name         = "RNAppMetadata"
   s.version      = "1.0.0"
   s.summary      = "RNAppMetadata"
-  s.description  = <<-DESC
-                  RNAppMetadata
-                   DESC
-  s.homepage     = ""
+  s.description  = "Get app metadata from Info.plist (iOS) or AndroidManifest.xml (android)"
+  s.homepage     = "https://github.com/CubeSugar/react-native-app-metadata"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNAppMetadata.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/CubeSugar/react-native-app-metadata/releases.git", :tag => "v1.0.0" }
   s.source_files  = "RNAppMetadata/**/*.{h,m}"
   s.requires_arc = true
-
-
   s.dependency "React"
-  #s.dependency "others"
 
 end
-
-  

--- a/ios/RNAppMetadata.podspec
+++ b/ios/RNAppMetadata.podspec
@@ -1,4 +1,3 @@
-
 Pod::Spec.new do |s|
   s.name         = "RNAppMetadata"
   s.version      = "1.0.0"
@@ -6,12 +5,10 @@ Pod::Spec.new do |s|
   s.description  = "Get app metadata from Info.plist (iOS) or AndroidManifest.xml (android)"
   s.homepage     = "https://github.com/CubeSugar/react-native-app-metadata"
   s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  s.author       = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/CubeSugar/react-native-app-metadata/releases.git", :tag => "v1.0.0" }
-  s.source_files  = "RNAppMetadata/**/*.{h,m}"
+  s.source       = { :git => "https://github.com/CubeSugar/react-native-app-metadata.git", :tag => "v1.0.0" }
+  s.source_files  = "*.{h,m}"
   s.requires_arc = true
   s.dependency "React"
-
 end


### PR DESCRIPTION
`pod install` fails on cocoapods-1.3.1 due to the following errors:

```[!] The `RNAppMetadata` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.```